### PR TITLE
Implements Maven URL when resolving artifacts

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala
@@ -193,7 +193,16 @@ class CoursierResolver(servers: List[DependencyServer], ec: ExecutionContext, ru
               .replaceAllLiterally("[ext]", Option(extension).filter(_.nonEmpty).getOrElse("jar"))
 
             Some(s"$url$subUrl")
-          case MavenServer(_, _, _) => None
+          case MavenServer(_, _, url) =>
+            // Builds a Maven artifact URL
+            def mavenUrl(url: String, organization: String, moduleName: String, version: String, classifier: Option[String], extension: Option[String]): String = {
+              val classifierSuffix: String = classifier.filter(_.nonEmpty).map("-" + _).getOrElse("")
+              val ext: String = extension.filter(_.nonEmpty).getOrElse("jar")
+
+              s"$url/${organization.replace('.', '/')}/$moduleName/$version/$moduleName-$version$classifierSuffix.$ext"
+            }
+
+            Some(mavenUrl(url, organization, moduleName, version, None, Option(extension)))
         }.flatten
 
 


### PR DESCRIPTION
Resolution was failing for an artifact only found in Maven repositories because at this point in the code it wasn't even looking into the Maven repositories.

Implemented it as a self contained method such that it can be easily moved to a better place.